### PR TITLE
Remove orgmode.org/elpa repository

### DIFF
--- a/elisp-check.el
+++ b/elisp-check.el
@@ -168,7 +168,6 @@ Only returns buffers for files that match PREFIX."
   "Setup package.el and install packages for the given CHECK."
   (package-initialize)
   (add-to-list 'package-archives '("melpa" . "http://melpa.org/packages/"))
-  (add-to-list 'package-archives '("org" . "http://orgmode.org/elpa/"))
   (package-refresh-contents)
   (elisp-check--install-packages (elisp-check--get-props check :package)))
 


### PR DESCRIPTION
Hi, thanks for creating this awesome package!
Currently it isn't possible to run checks, because the orgmode elpa repo is down. Here is my latest job for example: https://github.com/snowiow/aws.el/runs/3711990301?check_suite_focus=true

Because the org team announced to move to the official elpa repo(https://list.orgmode.org/87blb3epey.fsf@gnu.org/), I thought that it should solve the problem to just remove the repo now. It's already available there in version 9.4.6 as well and new releases (9.6 and above) will only be published on melpa.