### PR TITLE
Mention the fact that the melpa check is just a container for other tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ See the [COMPARISON.md](/COMPARISON.md) file for a more thorough comparison with
 ### Supported Checks
 
 * [melpa](https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org) :: Most checks required for MELPA
+    * Contains the checks load-file, byte-compile, package-lint and checkdoc
 * [load-file](https://www.gnu.org/software/emacs/manual/html_node/eintr/Loading-Files.html) :: Load files into Emacs
 * [byte-compile](https://www.gnu.org/software/emacs/manual/html_node/elisp/Byte-Compilation.html) :: Byte-compile files
 * [checkdoc](https://www.gnu.org/software/emacs/manual/html_node/elisp/Documentation-Tips.html#Documentation-Tips) :: Check documentation style

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ The above yaml code block shows the default configuration values for this GitHub
 
 | Name                 | Description                         | Type                                 |
 |----------------------|-------------------------------------|--------------------------------------|
-| `check`              | Emacs Lisp check to execute         | [Supported check](#supported-checks) |
+| `check`              | Emacs Lisp check to execute         | [Supported checks](#supported-checks)  |
 | `file`               | Entry file for Emacs Lisp check     | File with globbing                   |
 | `ignore_warnings`    | Whether to ignore warnings          | Boolean                              |
 | `warnings_as_errors` | Whether to treat warnings as errors | Boolean                              |


### PR DESCRIPTION
Hi

Thanks for your gh action! I'm using it for my emacs package. In order to find out which checks I should use I had to read the source to understand which checks are needed.

To spare the next user of your action of also having to read the source I thought it might be good to add something to the README that mentions the fact that the `melpa` check contains a number of other checks